### PR TITLE
Added execution_buffer argument

### DIFF
--- a/example_scripts/create_increase_order.py
+++ b/example_scripts/create_increase_order.py
@@ -59,5 +59,6 @@ order = IncreaseOrder(
     ),
     slippage_percent=order_parameters['slippage_percent'],
     swap_path=order_parameters['swap_path'],
-    debug_mode=True
+    debug_mode=True,
+    execution_buffer=1.5
 )

--- a/gmx_python_sdk/scripts/v2/order/deposit.py
+++ b/gmx_python_sdk/scripts/v2/order/deposit.py
@@ -27,7 +27,8 @@ class Deposit:
         long_token_amount: int,
         short_token_amount: int,
         max_fee_per_gas: int = None,
-        debug_mode: bool = False
+        debug_mode: bool = False,
+        execution_buffer: float = 1.1
     ) -> None:
         self.config = config
         self.market_key = market_key
@@ -39,6 +40,11 @@ class Deposit:
         self.short_token_swap_path = []
         self.max_fee_per_gas = max_fee_per_gas
         self.debug_mode = debug_mode
+        self.execution_buffer = execution_buffer
+
+        if self.debug_mode:
+            logging.info("Execution buffer set to: {:.2f}%".format(
+                (self.execution_buffer - 1) * 100))
 
         if self.max_fee_per_gas is None:
             block = create_connection(
@@ -163,7 +169,7 @@ class Deposit:
                 self._gas_limits,
                 self._gas_limits_order_type,
                 self._connection.eth.gas_price
-            ) * 1.1
+            ) * self.execution_buffer
         )
 
         callback_gas_limit = 0

--- a/gmx_python_sdk/scripts/v2/order/order.py
+++ b/gmx_python_sdk/scripts/v2/order/order.py
@@ -23,7 +23,7 @@ class Order:
         index_token_address: str, is_long: bool, size_delta: float,
         initial_collateral_delta_amount: str, slippage_percent: float,
         swap_path: list, max_fee_per_gas: int = None, auto_cancel: bool = False,
-        debug_mode: bool = False
+        debug_mode: bool = False, execution_buffer: float = 1.3
     ) -> None:
 
         self.config = config
@@ -38,6 +38,11 @@ class Order:
         self.max_fee_per_gas = max_fee_per_gas
         self.debug_mode = debug_mode
         self.auto_cancel = auto_cancel
+        self.execution_buffer = execution_buffer
+
+        if self.debug_mode:
+            logging.info("Execution buffer set to: {:.2f}%".format(
+                (self.execution_buffer - 1) * 100))
 
         if self.max_fee_per_gas is None:
             block = create_connection(
@@ -190,15 +195,7 @@ class Order:
         if not is_close and not self.debug_mode:
             self.check_for_approval()
 
-        # Up execution fee for swap, more complex
-        if is_swap:
-
-            # 30% buffer
-            execution_fee = int(execution_fee * 1.5)
-        else:
-
-            # 20% buffer
-            execution_fee = int(execution_fee * 1.3)
+        execution_fee = int(execution_fee * self.execution_buffer)
 
         markets = Markets(self.config).info
         initial_collateral_delta_amount = self.initial_collateral_delta_amount

--- a/gmx_python_sdk/scripts/v2/order/withdraw.py
+++ b/gmx_python_sdk/scripts/v2/order/withdraw.py
@@ -26,7 +26,9 @@ class Withdraw:
         out_token: str,
         gm_amount: int,
         max_fee_per_gas: int = None,
-        debug_mode: bool = False
+        debug_mode: bool = False,
+        execution_buffer: float = 1.1
+
     ) -> None:
         self.config = config
         self.market_key = market_key
@@ -36,6 +38,11 @@ class Withdraw:
         self.short_token_swap_path = []
         self.max_fee_per_gas = max_fee_per_gas
         self.debug_mode = debug_mode
+        self.execution_buffer = execution_buffer
+
+        if self.debug_mode:
+            logging.info("Execution buffer set to: {:.2f}%".format(
+                (self.execution_buffer - 1) * 100))
 
         if self.max_fee_per_gas is None:
             block = create_connection(
@@ -150,7 +157,7 @@ class Withdraw:
                 self._gas_limits,
                 self._gas_limits_order_type,
                 self._connection.eth.gas_price
-            ) * 1.1
+            ) * self.execution_buffer
         )
 
         callback_gas_limit = 0


### PR DESCRIPTION
When calling increase/decrease, deposit, or withdraw orders it is possible to pass execution buffer as decimal. For example, to add a 30% buffer pass 1.3. This will increase the amount of gas sent to the orderVault to perform execution. Any excess gas not used by the order vault will be returned to the users wallet.

Default is 30% (1.3) on increase/decrease orders and 20% (1.1) for deposit and withdraw orders. In debug mode it will print the buffer % to the terminal.