### PR TITLE
fix: convert token_amount_expanded to integer for contract calls

### DIFF
--- a/example_scripts/estimate_swap_output.py
+++ b/example_scripts/estimate_swap_output.py
@@ -72,7 +72,7 @@ class EstimateSwapOutput:
                 out_token_symbol
             )
         if token_amount_expanded is None:
-            token_amount_expanded = (
+            token_amount_expanded = int(
                 token_amount * 10 ** self.tokens[in_token_address]['decimals']
             )
 


### PR DESCRIPTION
   ## Issue
   When using decimal token amounts (e.g., 3.5 ETH), the SDK fails because the contract expects an integer value for token_amount_expanded.

   ## Fix
   Added integer conversion when calculating token_amount_expanded to ensure the contract receives the correct format.

   ## Testing
   Tested with decimal token amounts like 3.5 ETH, which now work correctly.