### PR TITLE
fix: updated python version requirement to support wide range of projects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = ["gmx_python_sdk", "gmx_python_sdk.*"]
 namespaces = false
 
 [tool.poetry.dependencies]
-python = ">= 3.10.4"
+python = ">=3.10.4,<4"
 numpy = ">= 1.26.3"
 hexbytes = ">= 0.3.1"
 web3 = ">= 6.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = ["gmx_python_sdk", "gmx_python_sdk.*"]
 namespaces = false
 
 [tool.poetry.dependencies]
-python = ">=3.10.4,<4"
+python = ">=3.10,<4"
 numpy = ">= 1.26.3"
 hexbytes = ">= 0.3.1"
 web3 = ">= 6.10.0"


### PR DESCRIPTION
## Summary

Updated the Python version to `python = ">=3.10,<4"` so that it can support a wide range of projects. 

## Fix

#2 

## Why

As we know many projects uses `poetry` which is a pain in the ass when it comes to version resolving. The current version will create huge conflicts. So it's safe to change the version to the one suggested in the PR.